### PR TITLE
identifies spring boot dependencies from project

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -14,7 +14,7 @@ var upgradeCmd = &cobra.Command{
 	},
 }
 
-var upgradeStatusCmd = &cobra.Command{
+var upgradeSpringBootCmd = &cobra.Command{
 	Use:   "spring-boot",
 	Short: "upgrade spring-boot to the latest version",
 	Long:  `upgrade spring-boot to the latest version`,
@@ -23,7 +23,23 @@ var upgradeStatusCmd = &cobra.Command{
 		if err != nil {
 			log.Println(err)
 		}
-		err = spring.Upgrade(targetDirectory)
+		err = spring.UpgradeSpringBoot(targetDirectory)
+		if err != nil {
+			log.Println(err)
+		}
+	},
+}
+
+var upgradeDependenciesCmd = &cobra.Command{
+	Use:   "dependencies",
+	Short: "upgrade dependencies to project",
+	Long:  `upgrade dependencies to project`,
+	Run: func(cmd *cobra.Command, args []string) {
+		targetDirectory, err := cmd.Flags().GetString("target")
+		if err != nil {
+			log.Println(err)
+		}
+		err = spring.UpgradeSpringDependencies(targetDirectory)
 		if err != nil {
 			log.Println(err)
 		}
@@ -32,6 +48,8 @@ var upgradeStatusCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.AddCommand(upgradeStatusCmd)
-	upgradeStatusCmd.Flags().String("target", ".", "Optional target directory")
+	upgradeCmd.AddCommand(upgradeSpringBootCmd)
+	upgradeCmd.AddCommand(upgradeDependenciesCmd)
+	upgradeSpringBootCmd.Flags().String("target", ".", "Optional target directory")
+	upgradeDependenciesCmd.Flags().String("target", ".", "Optional target directory")
 }

--- a/pkg/spring/types.go
+++ b/pkg/spring/types.go
@@ -10,8 +10,8 @@ type InitConfiguration struct {
 }
 
 type Dependency struct {
-	GroupID    string `json:"groupId"`
-	ArtifactID string `json:"artifactId"`
+	GroupId    string `json:"groupId"`
+	ArtifactId string `json:"artifactId"`
 	Scope      string `json:"scope"`
 	Version    string `json:"version,omitempty"`
 	Bom        string `json:"bom,omitempty"`


### PR DESCRIPTION
Tentativ.

For now, only prints the spring-boot deps found in project like:

```
Found spring-boot dependecy: org.springframework.boot:spring-boot-starter-web-services, on version: [] 
Found spring-boot dependecy: org.flywaydb:flyway-core, on version: [] 
Found spring-boot dependecy: org.springframework.boot:spring-boot-starter-data-jpa, on version: [] 
Found spring-boot dependecy: com.h2database:h2, on version: [] 
Found spring-boot dependecy: com.microsoft.sqlserver:mssql-jdbc, on version: [] 
Found spring-boot dependecy: io.micrometer:micrometer-registry-prometheus, on version: [] 
Found spring-boot dependecy: org.springframework.boot:spring-boot-starter-actuator, on version: []
```